### PR TITLE
Update Repair.php

### DIFF
--- a/Classes/SignalSlot/Repair.php
+++ b/Classes/SignalSlot/Repair.php
@@ -330,7 +330,8 @@ class Repair
                 unset($rows[$key]);
             }
         }
-
+        reset($rows);
+            
         return $rows;
     }
 
@@ -383,6 +384,7 @@ class Repair
                 unset($rows[$key]);
             }
         }
+        reset($rows);
 
         return $rows;
     }


### PR DESCRIPTION
Added reset of arrays containing (translated) sys-file references after foreach-loops. Otherwise, current() accessing those arrays will return false instead of the needed array element; e.g. Repair.php, line 70.